### PR TITLE
add option for streamplots

### DIFF
--- a/GCMtools/GCMtools.py
+++ b/GCMtools/GCMtools.py
@@ -313,6 +313,24 @@ class GCMT:
         ds = self._get_one_model(tag)
         gcmplt.isobaric_slice(ds, var_key, p, **kwargs)
 
+    def time_evol(self, var_key, tag=None, **kwargs):
+        """
+        Function that plots the time evolution of a quantity in a 1D line collection plot, where the colorscale can be related to the time evolution.
+        Note: var_key needs to contain data that is 2D in time and pressure.
+
+        Parameters
+        ----------
+        ds : DataSet
+            A GCMtools-compatible dataset of a 3D climate simulation.
+        var_key : str
+            The key of the variable quantity that should be plotted.
+        tag : str, optional
+            The tag of the dataset that should be plotted. If no tag is provided
+            and multiple datasets are available, an error is raised.
+        """
+        ds = self._get_one_model(tag)
+        gcmplt.time_evol(ds, var_key, **kwargs)
+
     def zonal_mean(self, var_key, tag=None, **kwargs):
         """
         Plot a zonal mean average of a quantity for the given dataset.

--- a/GCMtools/GCMtools.py
+++ b/GCMtools/GCMtools.py
@@ -292,7 +292,6 @@ class GCMT:
 
         return avg
 
-
     def isobaric_slice(self, var_key, p, tag=None, **kwargs):
         """
         Plot an isobaric slice of the given quantity at the given pressure

--- a/GCMtools/gcm_plotting.py
+++ b/GCMtools/gcm_plotting.py
@@ -112,13 +112,14 @@ def isobaric_slice(ds, var_key, p, time=-1, lookup_method='exact', ax=None,
         plot_horizontal_wind(ds2d, ax=ax, **wind_kwargs)
 
     # set other plot qualities
-    ax.set_aspect('equal')
-    xt=np.arange(-180, 181, 45)
-    yt=np.arange(-90, 91, 45)
-    ax.set_xticks(xt)
-    ax.set_yticks(yt)
-    ax.set_xticklabels([str(n)+r'$^\circ$' for n in xt], fontsize=fs_ticks)
-    ax.set_yticklabels([str(n) + r'$^\circ$' for n in yt], fontsize = fs_ticks)
+    if not hasattr(ax, "projection"):
+        ax.set_aspect('equal')
+        xt=np.arange(-180, 181, 45)
+        yt=np.arange(-90, 91, 45)
+        ax.set_xticks(xt)
+        ax.set_yticks(yt)
+        ax.set_xticklabels([str(n)+r'$^\circ$' for n in xt], fontsize=fs_ticks)
+        ax.set_yticklabels([str(n) + r'$^\circ$' for n in yt], fontsize = fs_ticks)
 
     ax.set_xlabel(xlabel, fontsize=fs_labels)
     ax.set_ylabel(ylabel, fontsize=fs_labels)

--- a/GCMtools/gcm_plotting.py
+++ b/GCMtools/gcm_plotting.py
@@ -14,6 +14,7 @@ def isobaric_slice(ds, var_key, p, time=-1, lookup_method='exact', ax=None,
                    plot_windvectors=True, wind_kwargs=None, cbar_kwargs=None,
                    add_colorbar = True, fs_labels=None, fs_ticks=None, title=None,
                    xlabel='Longitude (deg)', ylabel='Latitude (deg)',
+                   contourf = False,
                    **kwargs):
     """
     Plot an isobaric slice of the dataset and quantity at the given pressure
@@ -58,6 +59,8 @@ def isobaric_slice(ds, var_key, p, time=-1, lookup_method='exact', ax=None,
         X-axis label, longitude by default.
     ylabel : str, optional
         Y-axis label, latitude by default.
+    contourf: bool, optional
+        Decide if you want to do a contourplot or a pcolormesh plot
     """
     if ax is None:
         fig= plt.figure()
@@ -93,7 +96,10 @@ def isobaric_slice(ds, var_key, p, time=-1, lookup_method='exact', ax=None,
         raise ValueError("Please enter 'exact', 'nearest', or 'interpolate' as Z lookup method.")
 
     # Simple plot (with xarray.plot.pcolormesh)
-    plotted = ds2d[var_key].plot(add_colorbar=False, ax=ax, **kwargs)
+    if contourf:
+        plotted = ds2d[var_key].plot.contourf(add_colorbar=False, ax=ax, **kwargs)
+    else:
+        plotted = ds2d[var_key].plot.pcolormesh(add_colorbar=False, ax=ax, **kwargs)
 
     # make own colorbar, as the automatic colorbar is hard to customize
     if add_colorbar:
@@ -178,7 +184,7 @@ def plot_horizontal_wind(ds, ax=None, sample_one_in=1, arrowColor='k', windstrea
 
 def zonal_mean(ds, var_key, time=-1, ax=None,cbar_kwargs=None,
                fs_labels=None, xlabel='Longitude (deg)', ylabel='Z', add_ylabel_unit=True,
-               title=None, add_colorbar=True,
+               title=None, add_colorbar=True, contourf=False,
                **kwargs):
     """
     Plot a zonal mean average of a quantity for the given dataset.
@@ -207,8 +213,10 @@ def zonal_mean(ds, var_key, time=-1, ax=None,cbar_kwargs=None,
     title : str, optional
         Title for the isobaric slice plot. By default, the selected pressure
         and time stamp of the slice are displayed.
-    add_colorbar: bool, optional,
+    add_colorbar: bool, optional
         Optionally decide if you want a colorbar or don't
+    contourf: bool, optional
+        Decide if you want to do a contourplot or a pcolormesh plot
 
     """
     if ax is None:
@@ -230,7 +238,10 @@ def zonal_mean(ds, var_key, time=-1, ax=None,cbar_kwargs=None,
     zmean = ds[var_key].sel(time=time).mean(dim='lon')
 
     # Simple plot (with xarray.plot.pcolormesh)
-    plotted = zmean.plot(add_colorbar=False, ax=ax, **kwargs)
+    if contourf:
+        plotted = zmean.plot.contourf(add_colorbar=False, ax=ax, **kwargs)
+    else:
+        plotted = zmean.plot.pcolormesh(add_colorbar=False, ax=ax, **kwargs)
 
     # make own colorbar, as the automatic colorbar is hard to customize
     if add_colorbar:

--- a/GCMtools/gcm_plotting.py
+++ b/GCMtools/gcm_plotting.py
@@ -93,7 +93,7 @@ def isobaric_slice(ds, var_key, p, time=-1, lookup_method='exact', ax=None,
         raise ValueError("Please enter 'exact', 'nearest', or 'interpolate' as Z lookup method.")
 
     # Simple plot (with xarray.plot.pcolormesh)
-    plotted = ds2d[var_key].plot(add_colorbar=False, **kwargs)
+    plotted = ds2d[var_key].plot(add_colorbar=False, ax=ax, **kwargs)
 
     # make own colorbar, as the automatic colorbar is hard to customize
     if add_colorbar:
@@ -230,7 +230,7 @@ def zonal_mean(ds, var_key, time=-1, ax=None,cbar_kwargs=None,
     zmean = ds[var_key].sel(time=time).mean(dim='lon')
 
     # Simple plot (with xarray.plot.pcolormesh)
-    plotted = zmean.plot(add_colorbar=False, **kwargs)
+    plotted = zmean.plot(add_colorbar=False, ax=ax, **kwargs)
 
     # make own colorbar, as the automatic colorbar is hard to customize
     if add_colorbar:


### PR DESCRIPTION
This PR adds the possibility to have streamplots

```py
import cartopy.crs as ccrs
PROJECTION = ccrs.PlateCarree()

ax = plt.axes(projection = PROJECTION)
gcmt.isobaric_slice(p=1e-3, lookup_method='interpolate', var_key='T', wind_kwargs={'windstream':True, 'transform':PROJECTION}, transform=PROJECTION, ax=ax)
```

![Screen Shot 2022-06-10 at 09 29 22](https://user-images.githubusercontent.com/7556347/173013641-6c228b25-0bbb-49af-b808-22564bac3a81.png)
 
Since this only works when you have a cartopy axes, the code will only plot streams, whenever a cartopy axes is used and fall back to quiver else.