### PR TITLE
add convert script

### DIFF
--- a/GCMtools/exorad/read_in.py
+++ b/GCMtools/exorad/read_in.py
@@ -18,7 +18,7 @@ import GCMtools.core.writer as wrt
 from GCMtools.core.units import convert_pressure, convert_time
 
 
-def m_read_from_mitgcm(gcmt, data_path, iters, d_lon=5, d_lat=4, loaded_ds=None, **kwargs):
+def m_read_from_mitgcm(gcmt, data_path, iters, exclude_iters=None, d_lon=5, d_lat=4, loaded_ds=None, **kwargs):
     """
     Data read in for MITgcm output.
 
@@ -33,6 +33,10 @@ def m_read_from_mitgcm(gcmt, data_path, iters, d_lon=5, d_lat=4, loaded_ds=None,
         If None, no data will be read.
         If 'last' (default), only the last iteration will be read.
         If 'all', all iterations will be read.
+    exclude_iters: list, int, None
+        List iterations that you don't want to load
+        if None, no iterations from the list of iters will be excluded
+        if list: exclude from iters
     data_file : str
         Full path to the 'data' input file of MITgcm. If None, the default
         location of the file is assumed to be: data_path/data
@@ -56,6 +60,11 @@ def m_read_from_mitgcm(gcmt, data_path, iters, d_lon=5, d_lat=4, loaded_ds=None,
         iters = [max(all_iters)]
     elif iters == 'all':
         iters = find_iters_mitgcm(data_path, prefix)
+
+    if exclude_iters is not None:
+        if isinstance(exclude_iters, int):
+            exclude_iters = [exclude_iters]
+        iters = set(iters) - set(exclude_iters)
 
     wrt.write_status('INFO', 'Iterations: ' + ", ".join([str(i) for i in iters]))
 

--- a/GCMtools/utils/read_and_write.py
+++ b/GCMtools/utils/read_and_write.py
@@ -42,7 +42,10 @@ def m_read_raw(gcmt, gcm, data_path, iters='last', load_existing=False, tag=None
         from GCMtools.exorad import m_read_from_mitgcm
 
         if tag is not None and load_existing:
-            loaded_ds = gcmt.get_models(tag)
+            try:
+                loaded_ds = gcmt.get_models(tag)
+            except KeyError:
+                loaded_ds = None
         else:
             loaded_ds = None
 

--- a/bin/convert_to_gcmt
+++ b/bin/convert_to_gcmt
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+
+"""
+A Command line script that creates k-tables for exorad
+"""
+import os
+import argparse
+import yaml
+
+from GCMtools import GCMT
+
+wdir = os.getcwd()
+
+################
+# Default values
+################
+DEFAULT_CONFIG = os.path.join(wdir, 'convert.yaml')
+DEFAUT_PREFIXES = ["T","U","V","W"]
+DEFAULT_ITERATIONS = "all"
+DEFAULT_LOAD_EXISTING = False
+DEFAULT_GCM = "MITgcm"
+DEFAULT_TAG = "nc_convert"
+DEFAULT_DATA_PATH = os.path.join(wdir, 'run')
+DEFAULT_SAVE_PATH = os.path.join(wdir, 'results')
+
+########################
+# Command line arguments
+########################
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-c",
+    "--config",
+    help="specify the path to the config file that holds the config for converting to xarray",
+    default=DEFAULT_CONFIG,
+)
+args = parser.parse_args()
+
+###################################
+# Load config
+###################################
+if not os.path.isfile(args.config):
+    print("no config file found, using defaults instead")
+    config = {}
+else:
+    with open(args.config) as f:
+         config = yaml.load(f, Loader=yaml.FullLoader)
+
+################
+# Set parameters
+################
+iterations = config.pop("iters", DEFAULT_ITERATIONS)
+prefixes = config.pop("prefix", DEFAUT_PREFIXES)
+tag = config.pop("tag", DEFAULT_TAG)
+gcm = config.pop("gcm", DEFAULT_GCM)
+load_existing = config.pop("load_existing", DEFAULT_LOAD_EXISTING)
+data_path = config.pop("data_path", DEFAULT_DATA_PATH)
+save_path = config.pop("save_path", DEFAULT_SAVE_PATH)
+
+###############
+# Do conversion
+###############
+gcmt = GCMT(write='on')
+if load_existing:
+    gcmt.load(save_path, tag=tag)
+gcmt.read_raw(gcm=gcm, data_path=data_path, iters=iterations, prefix=prefixes, load_existing=load_existing, tag=tag, **config)
+gcmt.save(save_path, tag=tag)

--- a/bin/convert_to_gcmt
+++ b/bin/convert_to_gcmt
@@ -1,13 +1,14 @@
 #!/usr/bin/python
 
 """
-A Command line script that creates k-tables for exorad
+A Command line script that converts raw data to gcmt data
 """
 import os
 import argparse
 import yaml
 
 from GCMtools import GCMT
+import GCMtools.core.writer as wrt
 
 wdir = os.getcwd()
 
@@ -22,6 +23,8 @@ DEFAULT_GCM = "MITgcm"
 DEFAULT_TAG = "nc_convert"
 DEFAULT_DATA_PATH = os.path.join(wdir, 'run')
 DEFAULT_SAVE_PATH = os.path.join(wdir, 'results')
+DEFAULT_SAVE_METHOD = "nc"
+DEFAULT_UPDATE_ALONG_TIME = False
 
 ########################
 # Command line arguments
@@ -38,8 +41,10 @@ args = parser.parse_args()
 ###################################
 # Load config
 ###################################
+gcmt = GCMT(write='on')
+
 if not os.path.isfile(args.config):
-    print("no config file found, using defaults instead")
+    wrt.write_status('WARN', "Conversion to gcmt: no config file found, using defaults instead")
     config = {}
 else:
     with open(args.config) as f:
@@ -55,12 +60,13 @@ gcm = config.pop("gcm", DEFAULT_GCM)
 load_existing = config.pop("load_existing", DEFAULT_LOAD_EXISTING)
 data_path = config.pop("data_path", DEFAULT_DATA_PATH)
 save_path = config.pop("save_path", DEFAULT_SAVE_PATH)
+method = config.pop("method", DEFAULT_SAVE_METHOD)
+update_along_time = config.pop("update_along_time", DEFAULT_UPDATE_ALONG_TIME)
 
 ###############
 # Do conversion
 ###############
-gcmt = GCMT(write='on')
 if load_existing:
-    gcmt.load(save_path, tag=tag)
+    gcmt.load(save_path, tag=tag, method=method)
 gcmt.read_raw(gcm=gcm, data_path=data_path, iters=iterations, prefix=prefixes, load_existing=load_existing, tag=tag, **config)
-gcmt.save(save_path, tag=tag)
+gcmt.save(save_path, tag=tag, method=method, update_along_time=update_along_time)

--- a/doc/source/cli.rst
+++ b/doc/source/cli.rst
@@ -1,0 +1,56 @@
+Command Line Interface
+======================
+
+``GCMtools`` also provides some functionality to be used from the command line.
+The functionalites explained below are scripts, which are automatically installed into your environment, when installing ``GCMtools``.
+You can use them in your terminal by hitting the name of the script (e.g.:).
+Information on the required arguments can be found below, or by using the ``-h`` flag.
+
+
+convert_to_gcmt
+---------------
+
+The ``convert_to_gcmt`` script is meant to enable an intermediary step between postprocessing/dataanalysis/plotting and simulation outputs.
+``convert_to_gcmt`` reads the raw input of the GCM output and saves it to an intermediary dataformat (netcdf or zarr).
+
+The script could be used in the following way:
+
+1. Do climate simulation (remotely on cluster)
+2. Run ``convert_to_gcmt`` to convert the data to netcdf
+3. Download the netcdf data and load it into GCMtools
+4. Work on the data
+
+**Usage:**
+
+.. code-block:: bash
+
+    $ convert_to_gcmt -h
+    usage: convert_to_gcmt [-h] [-c CONFIG]
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -c CONFIG, --config CONFIG
+                            specify the path to the config file that holds the
+                            config for converting to xarray
+
+The use of a config file (yaml) for the script is optional, but highly recommended, since script will fallback to defaults, which might or might not work for your setup.
+If you do not provide any name for a config file, the script will search for ``convert.yaml`` in your current working directory.
+
+The following options are available in the ``convert.yaml`` file:
+
+.. code-block:: yaml
+
+    iters: "all"                 # list of iterations to load
+    prefix: ["T","U","V","W"]    # The file prefixes that you want to read
+    tag: "nc_convert"            # GCMT tag that should be created for your conversion
+    gcm: "MITgcm"                # The GCM for which we want to load the raw data
+    load_existing: False         # If we want to check for already converted input and just extend if available
+    data_path: "run"             # Path to the raw data
+    save_path: "results"         # Path at which the converted data should be stored
+    method: "nc"                 # Output format used for the conversion
+    update_along_time: False     # Only relevant if method == "zarr". Checkout GCMtools.GCMT.save for more info
+    # (anything else to be passed to GCMtools.GCMT.read_raw)
+
+.. Note:: All of the other arguments are input for :meth:`GCMtools.GCMT.read_raw`
+
+Checkout :meth:`GCMtools.GCMT.read_raw`, :meth:`GCMtools.GCMT.load` and :meth:`GCMtools.GCMT.save` to understand the usage of the above parameters.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -40,6 +40,7 @@ Capabilities
 
    installation
    usage
+   cli
    notebooks/demo.ipynb
 
    

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     version='v0.1.1',
     packages=find_packages(),
     include_package_data=True,
+    scripts=['bin/convert_to_gcmt'],
     url='https://github.com/exorad/GCMtools',
     license='MIT',
     author='Aaron David Schneider',
@@ -21,6 +22,7 @@ setup(
         "numpy",
         "f90nml",
         "astropy",
-        "xarray"
+        "xarray",
+        "pyyaml"
     ]
 )


### PR DESCRIPTION
This rather small PR adds a neat script that will be installed alongside with GCMtools, which enables easy conversion to a gcmt readable format (nc or zarr).

Here is how it works:
1. Install GCMtools with pip
2. construct a config file for the conversion (or use the defaults without a config file)
3. run the script (note: directories can be specified in yaml file, otherwise you should run the script from MITgcm simulation folder) - example:
```
$ cd W96b
$ ls
build                                   run
code                                    telegram_simulation_bot.session
convert.yaml                            telegram_simulation_bot.session-journal
exorad-34903910.err                     weights_tile1.nc
exorad-34903910.out                     weights_tile2.nc
exorad-34906337.err                     weights_tile3.nc
exorad-34906337.out                     weights_tile4.nc
input                                   weights_tile5.nc
results                                 weights_tile6.nc
$ convert_to_gcmt
```

Here is an example yaml convert file:
```yaml
prefix: ["T","U","V","W", "EXOBFPla","EXOBFStar", "Ttave"]
tag: 'W96b'
load_existing: True
```