### PR TITLE
delete auxiliary regrid weights

### DIFF
--- a/GCMtools/exorad/read_in.py
+++ b/GCMtools/exorad/read_in.py
@@ -81,7 +81,9 @@ def m_read_from_mitgcm(gcmt, data_path, iters, exclude_iters=None, d_lon=5, d_la
     ds_ascii, grid = cs.open_ascii_dataset(data_path, iters=to_load, prefix=prefix, **kwargs)
 
     # regrid the dataset
-    regrid = cs.Regridder(ds=ds_ascii, cs_grid=grid, d_lon=d_lon, d_lat=d_lat)
+    filename = 'tmp_gcmt_reg_weights_xya'  # generate random filename for weights to be deleted afterwards
+    regrid = cs.Regridder(ds=ds_ascii, cs_grid=grid, d_lon=d_lon, d_lat=d_lat, filename=filename)
+    [os.remove(f) for f in glob.glob(filename+"*.nc")]  # delete aux weights
     ds = regrid()
 
     # convert wind, vertical dimension, time, ...


### PR DESCRIPTION
I just don't want to see them anymore. They have been everywhere...
No honestly those regrid weights are useful in some cases, but GCMtools doesn't utilize them anyway, so we might as well just delete them after they have been used.