### PR TITLE
increase UX

### DIFF
--- a/GCMtools/GCMDatasetCollection.py
+++ b/GCMtools/GCMDatasetCollection.py
@@ -32,7 +32,7 @@ class GCMDatasetCollection(UserDict):
             Will definetly be GCMDatasetCollection if always_dict=True
         """
         if isinstance(tag, str):
-            return self[tag]
+            return self.get(tag)
 
         # If no tag is given, return all models
         if tag is None:
@@ -44,7 +44,7 @@ class GCMDatasetCollection(UserDict):
         # If the tag is not a string, raise an error
         wrt.write_status('ERROR', 'The given tag is not a string.')
 
-    def get_one_model(self, tag=None):
+    def get_one_model(self, tag=None, raise_error=True):
         """
         Helper Function that raises an error, if more than one model is selected.
 
@@ -52,6 +52,9 @@ class GCMDatasetCollection(UserDict):
         ----------
         tag: str, optional
             Name of the model that should be returned
+        raise_error: bool, optional
+            If true, function will raise error, else will return None if not one model is selected
+
         Returns
         -------
         ds: xarray Dataset
@@ -60,6 +63,9 @@ class GCMDatasetCollection(UserDict):
 
         # select the appropriate dataset
         ds = self.get_models(tag=tag)
+        # Raise error, if key not in collection and raise error is specified
+        if ds is None and raise_error:
+            raise KeyError('No dataset for given key available.')
         # if a collection is given (because multiple datasets are available, and
         # the tag is not provided), avoid ambiguity by raising an error
         if isinstance(ds, GCMDatasetCollection) and len(ds) > 1 and tag is None:

--- a/GCMtools/GCMDatasetCollection.py
+++ b/GCMtools/GCMDatasetCollection.py
@@ -23,7 +23,7 @@ class GCMDatasetCollection(UserDict):
         tag : str
             Name of the model that should be returned.
         always_dict: bool
-            Force result to be a dictionary
+            Force result to be a dictionary (if tag is None)
 
         Returns
         -------
@@ -46,7 +46,7 @@ class GCMDatasetCollection(UserDict):
 
     def get_one_model(self, tag=None, raise_error=True):
         """
-        Helper Function that raises an error, if more than one model is selected.
+        Helper Function that raises an error or returns None, if more than one model is selected.
 
         Parameters
         ----------

--- a/GCMtools/GCMtools.py
+++ b/GCMtools/GCMtools.py
@@ -181,7 +181,7 @@ class GCMT:
         tag : str
             Name of the model that should be returned.
         always_dict: bool
-            Force result to be a dictionary
+            Force result to be a dictionary (if tag is None)
 
         Returns
         -------

--- a/GCMtools/GCMtools.py
+++ b/GCMtools/GCMtools.py
@@ -6,11 +6,13 @@
 #  environment for new users of GCMs while allowing direct
 #  access to the data for more experienced users.
 # ==============================================================
+import xarray
 
 import GCMtools.core.writer as wrt
 import GCMtools.utils.gcm_plotting as gcmplt
 import GCMtools.utils.manipulations as mani
 import GCMtools.utils.read_and_write as raw
+from GCMtools.utils.passport import is_the_data_basic
 from GCMtools.GCMDatasetCollection import GCMDatasetCollection
 from GCMtools.core.units import ALLOWED_PUNITS, ALLOWED_TIMEUNITS
 
@@ -85,22 +87,89 @@ class GCMT:
         selected_models : GCMDatasetCollection or xarray Dataset
             All models in self._models
         """
-        return self._models.get_models()
+        return self.get_models()
 
-    def get_one_model(self, tag=None):
+    def __iter__(self):
         """
-        Like get_models, but raises an error, if more than one model is selected.
+        Returns an iterator of GCMT
+        """
+        return iter(self.get_models(always_dict=True).items())
+
+    def __getitem__(self, tag):
+        """
+        Access models of this dataset
+
+        Parameters:
+        -----------
+        tag: str
+            Tag of the model that should be returned
+
+        Returns
+        -------
+        selected_model : xarray Dataset
+        """
+        if tag not in self._models.keys():
+            raise ValueError('The provided tag does not exist in the collection')
+        if isinstance(tag, str):
+            return self.get_one_model(tag=tag, raise_error=True)
+        raise ValueError('key needs to be a string.')
+
+    def __setitem__(self, tag, ds):
+        """
+        Add or replaces a dataset
+
+        Parameters
+        ----------
+        tag: str
+           Tag at which the model should be stored
+        ds: xarray Dataset
+           Dataset to add
+        """
+        self._replace_model(tag, ds)
+
+    def __len__(self) -> int:
+        return len(self._models)
+
+    def __bool__(self) -> bool:
+        return bool(self._models)
+
+    def get(self, tag, default = None):
+        """
+        Pythonic get, will return default if tag is not available.
+
+        Parameters
+        ----------
+        tag: str
+            Name of the model that should be returned
+        default: Any
+            Default value in case that the tag is not available in the dataset
+
+        Returns
+        -------
+        ds or default, depending on whether ds is available
+        """
+        if ds := self.get_one_model(tag, raise_error=False):
+            return ds
+        else:
+            return default
+
+    def get_one_model(self, tag=None, raise_error=True):
+        """
+        Like get_models, but raises an error or return None, if more than one model is selected.
 
         Parameters
         ----------
         tag: str, optional
             Name of the model that should be returned
+        raise_error: bool, optional
+            If true, function will raise error, else will return None if not one model is selected
+
         Returns
         -------
         ds: xarray Dataset
             Selected model
         """
-        return self._models.get_one_model(tag)
+        return self._models.get_one_model(tag, raise_error)
 
     def get_models(self, tag=None, always_dict=False):
         """
@@ -122,17 +191,30 @@ class GCMT:
         """
         return self._models.get_models(tag, always_dict)
 
-    def replace_model(self, ds, tag):
+    def _replace_model(self, tag, ds):
         """
-        Function that adds or replaces a dataset
+        Add or replaces a dataset. Do some checks beforehand.
 
         Parameters
         ----------
-        ds: xarray Dataset
-           Dataset to add
         tag: str
            Tag at which the model should be stored
+        ds: xarray Dataset
+           Dataset to add
         """
+        if not isinstance(tag, str):
+            raise ValueError("The provided tag needs to be a string.")
+        if not isinstance(ds, xarray.Dataset):
+            raise ValueError("The provided input dataset needs to be a xarray Dataset.")
+        if not is_the_data_basic(ds):
+            raise ValueError("The provided input dataset is not compatible.")
+
+        if ds.attrs.get('p_unit') != self.p_unit:
+            raise NotImplementedError('Unit conversion is needed and not yet implemented')
+        if ds.attrs.get('time_unit') != self.time_unit:
+            raise NotImplementedError('Unit conversion is needed and not yet implemented')
+
+        ds.attrs.update({'tag': tag})
         self._models[tag] = ds
 
     # =============================================================================================================

--- a/GCMtools/utils/read_and_write.py
+++ b/GCMtools/utils/read_and_write.py
@@ -101,7 +101,7 @@ def _add_attrs_and_store(gcmt, ds, tag):
         raise ValueError('This dataset is not supported by GCMtools\n')
 
     # store dataset
-    gcmt.replace_model(ds, tag)
+    gcmt[tag] = ds
 
 
 def m_save(gcmt, dir, method='nc', update_along_time=False, tag=None):
@@ -214,4 +214,4 @@ def m_load(gcmt, dir, method='nc', tag=None):
         ds = convert_time(ds, current_unit=ds.attrs.get('time_unit'), goal_unit=gcmt.time_unit)
         ds = convert_pressure(ds, current_unit=ds.attrs.get('p_unit'), goal_unit=gcmt.p_unit)
 
-        gcmt.replace_model(ds, tag)
+        gcmt[tag] = ds

--- a/doc/source/notebooks/demo.ipynb
+++ b/doc/source/notebooks/demo.ipynb
@@ -84,7 +84,7 @@
       "\u001B[94m   [INFO] Tag: HD2\u001B[0m\n",
       "\u001B[94m   [INFO] File path: HD2_test/run\u001B[0m\n",
       "\u001B[94m   [INFO] Iterations: 38016000, 41472000\u001B[0m\n",
-      "time needed to build regridder: 1.2868068218231201\n",
+      "time needed to build regridder: 0.8923001289367676\n",
       "Regridder will use conservative method\n"
      ]
     }
@@ -118,7 +118,7 @@
    "execution_count": 3,
    "outputs": [],
    "source": [
-    "ds = gcmt.get_models('HD2')\n",
+    "ds = gcmt['HD2']\n",
     "# ds = gcmt.models # note this is equal, since we only loaded one dataset"
    ],
    "metadata": {
@@ -504,7 +504,7 @@
     },
     {
      "data": {
-      "text/plain": "<matplotlib.collections.LineCollection at 0x7f8f6b02d3a0>"
+      "text/plain": "<matplotlib.collections.LineCollection at 0x7fc1ad623c70>"
      },
      "execution_count": 11,
      "metadata": {},
@@ -603,6 +603,242 @@
    ],
    "source": [
     "gcmt.zonal_mean('psi')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Dealing with the GCMT object"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "GCMT binds in naturally into the pythonic environment. Here are a few examples of how you can interact with the GCMT object:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "print the amount of loaded models:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "1"
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(gcmt)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "check if a model is loaded:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bool(gcmt)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "iterate over models:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HD2 650.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "for tag, ds in gcmt:\n",
+    "    print(tag, ds.Z.max().values)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Retrieve a model:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "outputs": [],
+   "source": [
+    "ds = gcmt.get('HD2')   # pythonic get (you can also set a default)\n",
+    "ds = gcmt.get_models('HD2')  # GCMT get, with more options\n",
+    "ds = gcmt.get_one_model('HD2')  # can raise an error if you want to\n",
+    "ds = gcmt['HD2']  # normal pythonic __getitem__"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Set a model:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "outputs": [],
+   "source": [
+    "gcmt['HD2_clone'] = ds"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "You may want to check which of those is suited for your case. Just check the docs to find out:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on method get_models in module GCMtools.GCMtools:\n",
+      "\n",
+      "get_models(tag=None, always_dict=False) method of GCMtools.GCMtools.GCMT instance\n",
+      "    Function return all GCMs in memory. If a tag is given, only return this\n",
+      "    one.\n",
+      "    \n",
+      "    Parameters\n",
+      "    ----------\n",
+      "    tag : str\n",
+      "        Name of the model that should be returned.\n",
+      "    always_dict: bool\n",
+      "        Force result to be a dictionary\n",
+      "    \n",
+      "    Returns\n",
+      "    -------\n",
+      "    selected_models : GCMDatasetCollection or xarray Dataset\n",
+      "        All models in self._models, or only the one with the right tag.\n",
+      "        Will definetly be GCMDatasetCollection if always_dict=True\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(gcmt.get_models)"
    ],
    "metadata": {
     "collapsed": false,

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -18,12 +18,12 @@ It is used to load data into ``xarray`` datasets, which can then be used for ana
         gcmt = GCMT()
         gcmt.read_raw(..., tag='model_name')
         # gcmt.read_raw(..., tag='model_name_2')  # if you have multiple models
-        ds = gcmt.get_models('model_name')
+        ds = gcmt['model_name']
 
 The GCMT class can also be used for quick plotting of data, since it wraps a few plotting functions, which are outlined in :ref:`Plotting`.
 
 .. autoclass:: GCMtools.GCMT
-    :members: __init__, get_models, models, add_horizontal_average, add_meridional_overturning, read_raw, read_reduced, load, save
+    :members: __init__, get, get_models, models, add_horizontal_average, add_meridional_overturning, read_raw, read_reduced, load, save
 
 
 Plotting
@@ -41,7 +41,7 @@ Example:
         # Load data
         gcmt = GCMT()
         gcmt.read_raw(..., tag='model_name')
-        ds = gcmt.get_models('model_name')
+        ds = gcmt['model_name']
 
         # Plot data with GCMT
         gcmt.isobaric_slice(tag = 'model_name', p=1e-2, lookup_method='nearest', var_key='T', wind_kwargs={'windstream':False, 'sample_one_in':2})


### PR DESCRIPTION
Hi @robinbaeyens and @Kiefersv,

I implemented a few builtin functions that help GCMT to become more pythonic and in a way more like xarray.
I hope you like it. 

## Example
Here is a preview of what is now possible (this is also now part of the docs):

print the amount of loaded models:
```py
len(gcmt)
```
check if a model is loaded:
```py
bool(gcmt)
```
iterate over models:
```py
for tag, ds in gcmt:
    print(tag, ds.Z.max().values)
```
Retrieve a model:
```py
ds = gcmt.get('HD2')   # pythonic get (you can also set a default)
ds = gcmt.get_models('HD2')  # GCMT get, with more options
ds = gcmt.get_one_model('HD2')  # can raise an error if you want to
ds = gcmt['HD2']  # normal pythonic __getitem__
```
Set a model:
```py
gcmt['HD2_clone'] = ds
```
You may want to check which of those is suited for your case. Just check the docs to find out:
```py
help(gcmt.get_models)
```

Looking forward to your comments.

## Breaking changes
`gcmt.get_models(tag=wrong_tag)` will not raise an error if `wrong_tag` is not in available models, but instead return `None` (which is more pythonic for a function that has get in its name). You can use `gcmt.get_one_model` or `gcmt[tag]` for that.
